### PR TITLE
Remove "add credentials" line from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 
 1. Git pull this repository - ```git clone https://github.com/MycroftAI/docker-mycroft.git```
 
-2. Edit the Dockerfile and change the user:pass information in the Mycroft checkout line to your authorised username and password on Github for the MycroftAI repo.
-
-3. Build the docker image with 
+2. Build the docker image with 
    ```docker build -t <yourusername>/mycroft .``` in the directory that you have checked out.
 
-4. Start the image with ``` docker run --device /dev/snd:/dev/snd --privileged -it <youruser>/mycroft ```
+3. Start the image with ``` docker run --device /dev/snd:/dev/snd --privileged -it <youruser>/mycroft ```
 
-5. If you would rather have an interactive session (for testing, coding, or whatever) with the docker container, start the container with 
+4. If you would rather have an interactive session (for testing, coding, or whatever) with the docker container, start the container with 
    ```docker run --device /dev/snd:/dev/snd --privileged -it <youruser>/mycroft /bin/bash``` 
    Once the container is loaded, please run ```supervisord``` from the bash prompt to start the Mycroft services 


### PR DESCRIPTION
Commit [`b9d7c5d`](https://github.com/MycroftAI/docker-mycroft/commit/b9d7c5dd37584b83892de0ce84e3fbaeff16ec88) removes the need for the user to add their Github credentials. This PR updates the README to match.