### PR TITLE
Fixed Screen Issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,5 @@ ENV PYTHONPATH $PYTHONPATH:/mycroft/ai
 
 EXPOSE 8000
 
-Entrypoint ["/mycroft/ai/mycroft.sh", "start", "-d"]
+CMD ["/mycroft/ai/mycroft.sh", "start"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 ENV TERM linux
 ENV ENV DEBIAN_FRONTEND noninteractive
 
-COPY supervisord.conf /etc/supervisor/supervisord.conf
+
 COPY build_host_setup_debian.sh /usr/local/bin/
 COPY mycroft-core-amd64_0.8.12-1.deb /usr/local/bin
 COPY mimic-amd64_1.2.0.2-1.deb /usr/local/bin
@@ -32,7 +32,6 @@ RUN \
   # git fetch && git checkout dev && \ this branch is now merged to master
   easy_install pip==7.1.2 && \
   pip install -r requirements.txt --trusted-host pypi.mycroft.team && \
-  pip install supervisor && \
   dpkg -i /usr/local/bin/mimic-amd64_1.2.0.2-1.deb && \
   mkdir /mycroft/ai/mimic && \
   mkdir /mycroft/ai/mimic/bin && \
@@ -47,4 +46,3 @@ WORKDIR /mycroft/ai
 ENV PYTHONPATH $PYTHONPATH:/mycroft/ai
 EXPOSE 8000
 CMD ["/usr/bin/supervisord"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:16.04
 ENV TERM linux
 ENV ENV DEBIAN_FRONTEND noninteractive
 
+COPY supervisord.conf /etc/supervisor/supervisord.conf
 COPY build_host_setup_debian.sh /usr/local/bin/
 COPY mycroft-core-amd64_0.8.12-1.deb /usr/local/bin
 COPY mimic-amd64_1.2.0.2-1.deb /usr/local/bin
@@ -30,6 +31,7 @@ RUN \
   # git fetch && git checkout dev && \ this branch is now merged to master
   easy_install pip==7.1.2 && \
   pip install -r requirements.txt --trusted-host pypi.mycroft.team && \
+  pip install supervisor && \
   dpkg -i /usr/local/bin/mimic-amd64_1.2.0.2-1.deb && \
   mkdir /mycroft/ai/mimic && \
   mkdir /mycroft/ai/mimic/bin && \
@@ -44,5 +46,4 @@ ENV PYTHONPATH $PYTHONPATH:/mycroft/ai
 
 EXPOSE 8000
 
-CMD ["/mycroft/ai/mycroft.sh", "start"]
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN \
   apt-get update && \
   apt-get -y upgrade && \
   apt-get install -yq --no-install-recommends \
+  supervisor \
   dnsmasq \
   avrdude \
   jq \
@@ -41,9 +42,9 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 WORKDIR /mycroft/ai
 ENV PYTHONPATH $PYTHONPATH:/mycroft/ai
-
 EXPOSE 8000
+CMD ["/usr/bin/supervisord"]
 
-CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -7,13 +7,10 @@
 2. Build the docker image with 
    ```docker build -t <yourusername>/mycroft .``` in the directory that you have checked out.
    
-3. Run the following to start up mycroft and an bash shell in the container:
+3. Run the following to start up mycroft:
    ```docker run --device /dev/snd:/dev/snd -d -it <\youruser\>/mycroft```
-   
-4. By default the system will have a interactive bash shell that you can get to via the below command after running the container:
-   ```docker exec -it container_name /bin/bash```
 
-5. Confirm via docker ps that your container is up and serving port 8000:
+4. Confirm via docker ps that your container is up and serving port 8000:
 
 
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
    ```docker build -t <yourusername>/mycroft .``` in the directory that you have checked out.
    
 3. Run the following to start up mycroft:
-   ```docker run --device /dev/snd:/dev/snd -d -it <\youruser\>/mycroft```
+   ```docker run --device /dev/snd:/dev/snd -itd <\youruser\>/mycroft```
 
 4. Confirm via docker ps that your container is up and serving port 8000:
 
@@ -20,7 +20,7 @@ CONTAINER ID        IMAGE                                                COMMAND
 ```
 
 ### CLI Access
-You can interact with the CLI of the container by running the following command, this will connect you to the running container:
+You can interact with the CLI of the container by running the following command, this will connect you to the running container via bash:
 
 ```
 docker exec -it container_name /bin/bash

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 2. Build the docker image with 
    ```docker build -t <yourusername>/mycroft .``` in the directory that you have checked out.
-
-3. If you would rather have an interactive session (for testing, coding, or whatever) with the docker container, start the container with the following, then you would need to start mycroft with the /mycroft/ai/mycroft.sh script.
-   ```docker run --device /dev/snd:/dev/snd --privileged -it <youruser>/mycroft /bin/bash```
    
-4. Otherwise run the following to start up mycroft and an active cli session in the container:
+3. Run the following to start up mycroft and an bash shell in the container:
    ```docker run --device /dev/snd:/dev/snd -d -it <\youruser\>/mycroft```
+   
+4. By default the system will have a interactive bash shell that you can get to via the below command after running the container:
+   ```docker exec -it container_name /bin/bash```
 
 5. Confirm via docker ps that your container is up and serving port 8000:
 
@@ -26,7 +26,7 @@ CONTAINER ID        IMAGE                                                COMMAND
 You can interact with the CLI of the container by running the following command, this will connect you to the running container:
 
 ```
-docker attach container_name
+docker exec -it container_name /bin/bash
 ```
 
 You can exit this container safely and leave it running by hitting cntrl + p + q

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,6 +2,7 @@
 logfile=/var/log/supervisord.log
 loglevel=error
 user=root
+nodaemon=true
 
 [program:mycroftservice]
 command=/mycroft/ai/mycroft.sh start

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,14 @@
+[supervisord]
+logfile=/var/log/supervisord.log
+loglevel=error
+user=root
+
+[program:mycroftservice]
+command=/mycroft/ai/mycroft.sh start
+directory=/mycroft/ai/
+user=root
+autostart=true
+autorestart=true
+stderr_logfile=/var/log/mycroft.err.log
+stdout_logfile=/var/log/mycroft.out.log
+redirect_stderr=true


### PR DESCRIPTION
Reverted back to using supervisord since processes weren't staying up correctly.  Have image working correctly now.  Still see 1 issue with multiple --quiet sessions opening I need to figure out, but everything else is working fine.

root@23bbbb02da20:/mycroft/ai# screen -r
There are several suitable screens on:
	1755.mycroft-service	(05/16/17 13:21:01)	(Detached)
	1699.mycroft-cli--quiet	(05/16/17 13:20:59)	(Detached)
	1659.mycroft-voice	(05/16/17 13:20:57)	(Detached)
	1522.mycroft-skills	(05/16/17 13:20:56)	(Detached)
	1465.mycroft-cli--quiet	(05/16/17 13:20:53)	(Detached)
	1193.mycroft-cli--quiet	(05/16/17 13:20:47)	(Detached)
	876.mycroft-cli--quiet	(05/16/17 13:20:41)	(Detached)
	630.mycroft-cli--quiet	(05/16/17 13:20:35)	(Detached)
	278.mycroft-cli--quiet	(05/16/17 13:20:29)	(Detached)
	77.mycroft-cli--quiet	(05/16/17 13:20:23)	(Detached)
Type "screen [-d] -r [pid.]tty.host" to resume one of them.