### PR TITLE
RUN trying to run `alsa-utils`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN \
   dnsmasq \
   avrdude \
   jq \
-  pulseaudio && \
+  pulseaudio \
   alsa-utils && \
   cd /usr/local/bin && \
   /bin/bash build_host_setup_debian.sh && \


### PR DESCRIPTION
Massive chained commands were trying to run `alsa-utils` when should be installing/updating.