### PR TITLE
Fix trailing forward slash in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV ENV DEBIAN_FRONTEND noninteractive
 
 #For now copying deb files over to install
 COPY build_host_setup_docker.sh /usr/local/bin/
-COPY mycroft-core-amd64_0.8.20-1.deb /usr/local/bin
+COPY mycroft-core-amd64_0.8.20-1.deb /usr/local/bin/
 
 # Install Server Dependencies for Mycroft
 RUN \


### PR DESCRIPTION
Dockerfile was failing to build without the trailing slash in the `COPY` command.