### PR TITLE
README.md: updated to reflect the need for persistent skills storage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker build -t mycroft .
 ```
 
 ## Run
-To get persistent data and don't have, for example, to pair our instance every time the container is started. You can map a local directory into the container. Just replace the directory_on_local_machine with where you want the container mapped on your local machine (eg: /home/user/mycroft).
+To get persistent data and don't have, for example, to pair our instance every time the container is started. You can map a local directory into the container. Just replace the `config_dir_on_host` with where you want the container mapped on your local machine (e.g. `/home/user/mycroft`). To get persistent storage of non-default skills, so that they don't have to be re-installed every time the container is started, we map the container's `skills` directory to a local directory. Just replace the `skills_dir_on_host` with the desired location (e.g. `/home/user/mycroft_skills`).
 
 Sounds can be played in the container using pulseaudio, without modifying any config files (Thanks to [fsmunoz](https://github.com/jessfraz/dockerfiles/issues/85#issuecomment-299431931)).
 
@@ -35,7 +35,8 @@ Run the following to start up mycroft:
 
 ```bash
 docker run -d \
--v directory_on_local_machine:/root/.mycroft \
+-v config_dir_on_host:/root/.mycroft \
+-v skills_dir_on_host:/opt/mycroft/skills \
 --device /dev/snd \
 -e PULSE_SERVER=unix:${XDG_RUNTIME_DIR}/pulse/native \
 -v ${XDG_RUNTIME_DIR}/pulse/native:${XDG_RUNTIME_DIR}/pulse/native \


### PR DESCRIPTION
If the contents of `/opt/mycroft/skills` are not persisted to the host machine then non-default skills have to be reinstalled upon every container start and skill configuration must be performed again. I've updated README.md to include a bind mount for that directory.