### PR TITLE
Dockerfile: install procps in order to provide pgrep for...

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,13 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN set -x \
 	&& sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list \
 	&& apt-get update \
-	&& apt-get -y install git python3 python3-pip locales sudo \
+	&& apt-get -y install \
+	git \
+	locales \
+	procps \
+	python3 \
+	python3-pip \
+	sudo \
 	&& pip3 install future msm \
 	# Checkout Mycroft
 	&& git clone https://github.com/MycroftAI/mycroft-core.git /opt/mycroft \


### PR DESCRIPTION
...both start-mycroft.sh and stop-mycroft.sh, adopt multi-line, sorted package list in accord with Dockerfile best practices.

Both start-mycroft.sh and stop-mycroft.sh require pgrep, which is provided by the procps package. I've also made the package list mult-line and sorted, in accordance with [Dockerfile best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#sort-multi-line-arguments).